### PR TITLE
Calculate inertial using meshlab

### DIFF
--- a/abb_irb1200_gazebo/config/irb1200_5_90_arm_controller.yaml
+++ b/abb_irb1200_gazebo/config/irb1200_5_90_arm_controller.yaml
@@ -8,12 +8,12 @@ arm_controller:
      - joint_5
      - joint_6
   gains:
-    joint_1: {p: 100.0, i: 1.0, d: 0.0}
-    joint_2: {p: 100.0, i: 1.0, d: 0.0}
-    joint_3: {p: 100.0, i: 1.0, d: 0.0}
-    joint_4: {p: 100.0, i: 1.0, d: 0.0}
+    joint_1: {p: 1000.0, i: 500.0, d: 20.0}
+    joint_2: {p: 1000.0, i: 500.0, d: 20.0}
+    joint_3: {p: 1000.0, i: 500.0, d: 20.0}
+    joint_4: {p: 200.0, i: 100.0, d: 0.0}
     joint_5: {p: 100.0, i: 1.0, d: 0.0}
-    joint_6: {p: 100.0, i: 1.0, d: 0.0}
+    joint_6: {p: 100.0, i: 20.0, d: 0.0}
   constraints:
       goal_time: 0.6
       stopped_velocity_tolerance: 0.05

--- a/abb_irb1200_support/urdf/inertials.m
+++ b/abb_irb1200_support/urdf/inertials.m
@@ -1,0 +1,100 @@
+% Total robot mass taken from the IRB1200 datasheet
+total_robot_mass = 54.0;
+
+% Per link volume calculate using meshlab.
+volume_base_link = 0.012603;
+volume_link_1 = 0.010835;
+volume_link_2 = 0.016048;
+volume_link_3 = 0.006829;
+volume_link_4 = 0.002511;
+volume_link_5 = 0.000576;
+% Link_6 is modeled as a cylinder.
+volume_link_6 = pi*0.02^2*0.005;
+
+total_robot_volume = volume_base_link + volume_link_1 + volume_link_2 + volume_link_3 + volume_link_4 + volume_link_5 + volume_link_6;
+robot_density = total_robot_mass / total_robot_volume;
+
+mass_base_link = robot_density * volume_base_link;
+mass_link_1 = robot_density * volume_link_1;
+mass_link_2 = robot_density * volume_link_2;
+mass_link_3 = robot_density * volume_link_3;
+mass_link_4 = robot_density * volume_link_4;
+mass_link_5 = robot_density * volume_link_5;
+mass_link_6 = robot_density * volume_link_6;
+
+% Verify that the mass calculation was correct.
+robot_mass_check = mass_base_link + mass_link_1  + mass_link_2 + mass_link_3 + mass_link_4 + mass_link_5 + mass_link_6;
+if (abs(robot_mass_check - total_robot_mass) > 1e-10)
+  printf ("Something is wrong with the per link mass calculatation:\n")
+  total_robot_mass
+  robot_mass_check
+  exit
+endif
+
+function inertia = scale_inertia(inertia, mass, volumen, scale)
+  inertia = inertia ./ scale^5;
+  inertia = (inertia .* mass) ./ volumen;
+endfunction
+
+
+function print_inertial(meshlab_inertia, mass, volume, center_of_mass, scale)
+  inertia = scale_inertia(meshlab_inertia, mass, volume, scale);
+  printf("      <inertial>\n");
+  printf("        <mass value=\"%g\"/>\n", mass);      
+  printf("        <origin xyz=\"%g %g %g\"/>\n", center_of_mass(1), center_of_mass(2), center_of_mass(3));      
+  printf("        <inertia ixx=\"%g\" ixy=\"%g\" ixz=\"%g\" iyy=\"%g\" iyz=\"%g\" izz=\"%g\"/>\n", inertia(1,1), inertia(1,2), inertia(1,3), inertia(2,2), inertia(2,3), inertia(3,3))
+  printf("      </inertial>\n");
+endfunction
+
+
+printf("\n** base_link:\n")
+inertia = [9.332476   0.045335   0.028470;
+            0.045335  12.781226  -0.022451;
+            0.028470  -0.022451  11.934223];
+center_of_mass = [-0.028986 0.000596 0.112730];
+print_inertial(inertia, mass_base_link, volume_base_link, center_of_mass, 10);
+
+printf("\n** link_1:\n")
+inertial = [10.242188  -0.004163   0.025707;
+            -0.004163   8.373408  -0.010056;
+            0.025707  -0.010056   8.019296];
+center_of_mass = [0.000877 -0.000631 0.336217];
+print_inertial(inertial, mass_link_1, volume_link_1, center_of_mass, 10);
+
+printf("\n** link_2:\n")
+inertial = [45.159019   0.001209   0.019125;
+            0.001209  42.357410  -0.164604;
+            0.019125  -0.164604   8.181775];
+center_of_mass = [-0.000928 -0.000497 0.250051];
+print_inertial(inertial, mass_link_2, volume_link_2, center_of_mass, 10);
+
+printf("\n** link_3:\n")
+inertial = [  2.309597   0.013060  -0.517453;
+  0.013060   8.293624   0.013012;
+ -0.517453   0.013012   7.549211];
+center_of_mass = [0.099588 0.001143 0.032333];
+print_inertial(inertial, mass_link_3, volume_link_3, center_of_mass, 10);
+
+printf("\n** link_4:\n")
+inertial = [  0.524367  -0.011997   0.034790;
+ -0.011997   1.082882  -0.002073;
+  0.034790  -0.002073   1.046977];
+center_of_mass = [0.381678 0.001261 0.005168];
+print_inertial(inertial, mass_link_4, volume_link_4, center_of_mass, 10);
+
+printf("\n** link_5:\n")
+inertial = [ 0.046006  -0.000944  -0.000008;
+-0.000944   0.099600   0.000019;
+-0.000008   0.000019   0.084074];
+center_of_mass = [0.011197 -0.001056 0.000109];
+print_inertial(inertial, mass_link_5, volume_link_5, center_of_mass, 10);
+
+printf("\n** link_6:\n")
+% Link 6 is so small that without the scaling meshlab could not calculate
+% th volume and to get an inertia tensor I needed to scale it 100 times
+% (instead of 10 like the rest).
+inertial =  [ 12.367648  -0.000111   0.000084;
+ -0.000111   6.311567  -0.001112;
+  0.000084  -0.001112   6.314166];
+center_of_mass = [-0.250976 -0.000189 0.010218]/100;
+print_inertial(inertial, mass_link_6, volume_link_6, center_of_mass, 100);

--- a/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="abb_irb1200_5_90" params="prefix">
+
     <!-- link list -->
     <link name="${prefix}base_link">
       <inertial>
-        <mass value="6.215"/>
-        <origin xyz="-0.04204 8.01E-05 0.07964" rpy="0 0 0"/>
-        <inertia ixx="0.0247272" ixy="-8.0784E-05" ixz="0.00130902" iyy="0.0491285" iyz="-8.0419E-06" izz="0.0472376"/>
+        <mass value="13.7742"/>
+        <origin xyz="-0.028986 0.000596 0.11273"/>
+        <inertia ixx="0.101998" ixy="0.000495482" ixz="0.000311158" iyy="0.13969" iyz="-0.000245375" izz="0.130433"/>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -22,11 +23,12 @@
         </material>
       </visual>
     </link>
+
     <link name="${prefix}link_1">
       <inertial>
-        <mass value="3.067" />
-        <origin xyz="9.77E-05 -0.00012 0.23841" rpy="0 0 0"/>
-        <inertia ixx="0.0142175" ixy="-1.28579E-05" ixz="-2.31364E-05" iyy="0.0144041" iyz="1.93404E-05" izz="0.0104533"/>
+        <mass value="11.8419"/>
+        <origin xyz="0.000877 -0.000631 0.336217"/>
+        <inertia ixx="0.11194" ixy="-4.54988e-05" ixz="0.000280961" iyy="0.0915158" iyz="-0.000109905" izz="0.0876456"/>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -40,11 +42,12 @@
         <material name="yellow"/>
       </visual>
     </link>
+
     <link name="${prefix}link_2">
       <inertial>
-        <mass value="3.909"/>
-        <origin xyz="0.00078 -0.00212 0.10124" rpy="0 0 0"/>
-        <inertia ixx="0.0603111" ixy="9.83431E-06" ixz="5.72407E-05" iyy="0.041569" iyz="-0.00050497" izz="0.0259548"/>
+        <mass value="17.5394"/>
+        <origin xyz="-0.000928 -0.000497 0.250051"/>
+        <inertia ixx="0.493558" ixy="1.32136e-05" ixz="0.000209024" iyy="0.462939" iyz="-0.00179901" izz="0.0894214"/>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -58,11 +61,12 @@
         <material name="yellow"/>
       </visual>
     </link>
+
     <link name="${prefix}link_3">
       <inertial>
-        <mass value="2.944"/>
-        <origin xyz="0.02281 0.00106 0.05791" rpy="0 0 0"/>
-        <inertia ixx="0.00835606" ixy="-8.01545E-05" ixz="0.00142884" iyy="0.016713" iyz="-0.000182227" izz="0.0126984"/>
+        <mass value="7.46365"/>
+        <origin xyz="0.099588 0.001143 0.032333"/>
+        <inertia ixx="0.0252424" ixy="0.000142737" ixz="-0.00565542" iyy="0.0906438" iyz="0.000142213" izz="0.0825079"/>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -76,11 +80,12 @@
         <material name="yellow"/>
       </visual>
     </link>
+
     <link name="${prefix}link_4">
       <inertial>
-        <mass value="1.328"/>
-        <origin xyz="0.2247 0.00015 0.00041" rpy="0 0 0"/>
-        <inertia ixx="0.00284661" ixy="-2.12765E-05" ixz="-1.6435E-05" iyy="0.00401346" iyz="1.31336E-05" izz="0.0052535"/>
+        <mass value="2.74436"/>
+        <origin xyz="0.381678 0.001261 0.005168"/>
+        <inertia ixx="0.00573099" ixy="-0.000131119" ixz="0.000380232" iyy="0.0118352" iyz="-2.26565e-05" izz="0.0114428"/>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -94,11 +99,12 @@
         <material name="yellow"/>
       </visual>
     </link>
+
     <link name="${prefix}link_5">
       <inertial>
-        <mass value="0.546"/>
-        <origin xyz="-0.00109 3.68E-05 6.22E-05" rpy="0 0 0"/>
-        <inertia ixx="0.000404891" ixy="1.61943E-06" ixz="8.46805E-07" iyy="0.000892825" iyz="-1.51792E-08" izz="0.000815468"/>
+        <mass value="0.62953"/>
+        <origin xyz="0.011197 -0.001056 0.000109"/>
+        <inertia ixx="0.000502815" ixy="-1.03173e-05" ixz="-8.74347e-08" iyy="0.00108856" iyz="2.07657e-07" izz="0.000918873"/>
       </inertial>
       <collision name="collision">
         <geometry>
@@ -112,12 +118,21 @@
         <material name="yellow"/>
       </visual>
     </link>
+
     <link name="${prefix}link_6">
       <inertial>
         <mass value="0.137"/>
         <origin xyz="-0.00706 -0.00017 -1.32E-06" rpy="0 0 0"/>
         <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
       </inertial>
+      <!--
+      Meshlab calculated values make the robot crash when rotating this joint.
+      <inertial>
+        <mass value="0.00686711"/>
+        <origin xyz="-0.00250976 -1.89e-06 0.00010218"/>
+        <inertia ixx="1.3517e-06" ixy="-1.21316e-11" ixz="9.18065e-12" iyy="6.89813e-07" iyz="-1.21534e-10" izz="6.90097e-07"/>
+      </inertial>
+      -->
       <collision name="collision">
         <geometry>
           <mesh filename="package://abb_irb1200_support/meshes/irb1200_5_90/collision/link_6.stl"/>

--- a/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
+++ b/abb_irb1200_support/urdf/irb1200_5_90_macro.xacro
@@ -155,7 +155,7 @@
       <parent link="${prefix}base_link"/>
       <child link="${prefix}link_1"/>
       <limit effort="10000" lower="-2.967" upper="2.967" velocity="5.027"/>
-      <dynamics damping="1.0" friction="1.0"/>
+      <dynamics damping="50.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_2">
       <origin xyz="0 0 0.399" rpy="0 0 0"/>
@@ -163,7 +163,7 @@
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <limit effort="10000" lower="-1.745" upper="2.269" velocity="4.189"/>
-      <dynamics damping="1.0" friction="1.0"/>
+      <dynamics damping="50.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_3">
       <origin xyz="0 0 0.448" rpy="0 0 0"/>
@@ -173,7 +173,7 @@
       <!-- Original values: <limit effort="0" lower="-3.491" upper="1.222" velocity="5.236"/> -->
       <!-- Hacked limits for our robot since trac_ik doesn't yet get joint limits from params: -->
       <limit effort="10000" lower="-0.5" upper="1.2" velocity="5.236"/>
-      <dynamics damping="1.0" friction="1.0"/>
+      <dynamics damping="10.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_4">
       <origin xyz="0 0 0.042" rpy="0 0 0"/>
@@ -183,7 +183,7 @@
       <!-- Original values: <limit effort="0" lower="-4.712" upper="4.712" velocity="6.981"/> -->
       <!-- Hacked limits for our robot since trac_ik doesn't yet get joint limits from params: -->
        <limit effort="10000" lower="-2.8" upper="2.8" velocity="6.981"/>
-      <dynamics damping="1.0" friction="1.0"/>
+      <dynamics damping="5.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_5">
       <origin xyz="0.451 0 0 " rpy="0 0 0"/>
@@ -191,7 +191,7 @@
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
       <limit effort="10000" lower="-2.269" upper="2.269" velocity="7.069"/>
-      <dynamics damping="1.0" friction="1.0"/>
+      <dynamics damping="2.0" friction="1.0"/>
     </joint>
     <joint type="revolute" name="${prefix}joint_6">
       <origin xyz="0.082 0 0 " rpy="0 0 0"/>


### PR DESCRIPTION
Update irb 1200 5/90 inertials, joint dynamics and PID values.

## Intertials

I used Meshlab to calculate the inertia tensor, the center of mass and the volume of each collision mesh. I then scaled those values using a simple octave script (added to the repo, not so sure about that). To improve the resolution I scaled the meshes 10 times (or 100 for link 6) in Meshlab. The octave script then scales the results back.

This is the method explained in this [very well known tutorial](http://gazebosim.org/tutorials?tut=inertia).

To calculate each link mass a constant density in the entire robot was assumed and then distributed the mass using the calculated volume of each link.

I used the obtained values for all joints except for `joint_6` where they made the robot "crash". Maybe it's because the values are too small? @jonbinney did you experience similar problems? In this case, I left the previous values which seem to work fine.

The new inertials look like this:
![screenshot from 2019-02-28 19-56-24](https://user-images.githubusercontent.com/764126/53590851-fbf65680-3b92-11e9-9ef4-46267a9e9393.png)

I do no longer use the cylinder approximation for link 6 (as that one did not work either) so https://github.com/iron-ox/abb/pull/3 is NO longer needed.

## Dynamics and control

In order to have some idea of how well the control was performing I used gazebo plotting tool while setting different poses to the joints. The original values made the robot oscillate significantly while moving, as can be seen on this plot:
![screenshot from 2019-02-28 18-58-01](https://user-images.githubusercontent.com/764126/53590931-26481400-3b93-11e9-8705-d87d78874003.png)

The new values make the robot move smoothly and pretty quickly:
![screenshot from 2019-02-28 19-43-44](https://user-images.githubusercontent.com/764126/53590304-c2711b80-3b91-11e9-91bc-dba072267589.png)

I'm pretty sure that we can find even better values if we keep tuning, for example to reduce even more the steady state errors, but I believe that the proposed values are already very adequate.

## Testing

Start the simulation:
```
$ roslaunch abb_irb1200_gazebo  irb1200_5_90_gazebo.launch
```
Test the controllers:
```
$ rosrun rqt_joint_trajectory_controller rqt_joint_trajectory_controller arm_controller/command:=joint_path_command arm_controller/state:=feedback_states
```